### PR TITLE
Re-enable playback settings

### DIFF
--- a/app/time/style/time.less
+++ b/app/time/style/time.less
@@ -52,9 +52,6 @@
   background-color: white;
   opacity: 0.58;
 }
-button[data-target='#playback-settings'] {
-  display: none;
-}
 .fullscreen-button {
   display: none;
 }


### PR DESCRIPTION
Unhides the button for playback settings and has the button match its neighbours.
Includes a modification to story-tools.

MapStory issue #1324