### PR TITLE
Replace $rootScope with PubSub.js.

### DIFF
--- a/app/frames/frameController.js
+++ b/app/frames/frameController.js
@@ -1,4 +1,4 @@
-const moment = require("moment");
+import moment from "moment";
 
 function frameController(
   $scope,
@@ -216,5 +216,4 @@ function frameController(
     $scope.frameSettings.splice(index, 1);
   };
 }
-
-module.exports = frameController;
+export default frameController;

--- a/app/frames/frameController.js
+++ b/app/frames/frameController.js
@@ -2,7 +2,6 @@ const moment = require("moment");
 
 function frameController(
   $scope,
-  $rootScope,
   $log,
   $injector,
   $timeout,
@@ -51,7 +50,7 @@ function frameController(
 
   $scope.drawBoundingBox = () => {
     $scope.clearBoundingBox();
-    const bbVector = new ol.source.Vector({wrapX: false});
+    const bbVector = new ol.source.Vector({ wrapX: false });
     const vector = new ol.layer.Vector({
       source: bbVector
     });
@@ -60,11 +59,11 @@ function frameController(
     });
     const style = new ol.style.Style({
       stroke: new ol.style.Stroke({
-        color: '#FFF',
+        color: "#FFF",
         width: 3
       }),
       fill: new ol.style.Fill({
-        color: [255,255,255, 0]
+        color: [255, 255, 255, 0]
       })
     });
     const geometryFunction = ol.interaction.Draw.createRegularPolygon(4);
@@ -157,11 +156,18 @@ function frameController(
   };
 
   $scope.editStoryframe = index => {
-    document.getElementById("frameTitle").value = $scope.frameSettings[index].title;
-    document.getElementById("startDate").value = $scope.formatDates($scope.frameSettings[index].startDate);
-    document.getElementById("startTime").value = $scope.frameSettings[index].startTime;
-    document.getElementById("endDate").value = $scope.formatDates($scope.frameSettings[index].endDate);
-    document.getElementById("endTime").value = $scope.frameSettings[index].endTime;
+    document.getElementById("frameTitle").value =
+      $scope.frameSettings[index].title;
+    document.getElementById("startDate").value = $scope.formatDates(
+      $scope.frameSettings[index].startDate
+    );
+    document.getElementById("startTime").value =
+      $scope.frameSettings[index].startTime;
+    document.getElementById("endDate").value = $scope.formatDates(
+      $scope.frameSettings[index].endDate
+    );
+    document.getElementById("endTime").value =
+      $scope.frameSettings[index].endTime;
     $scope.frameSettings.bb1 = transformCoords([
       $scope.coords[0][0][0],
       $scope.coords[0][0][1]
@@ -209,7 +215,6 @@ function frameController(
   $scope.deleteStoryframe = index => {
     $scope.frameSettings.splice(index, 1);
   };
-
 }
 
 module.exports = frameController;

--- a/app/frames/frameSvc.js
+++ b/app/frames/frameSvc.js
@@ -1,7 +1,7 @@
 import moment from "moment";
 import PubSub from "pubsub-js";
 
-export default function frameSvc(stateSvc) {
+function frameSvc(stateSvc) {
   const svc = {};
 
   PubSub.subscribe("updateStoryframes", (event, chapters) => {
@@ -31,3 +31,5 @@ export default function frameSvc(stateSvc) {
 
   return svc;
 }
+
+export default frameSvc;

--- a/app/frames/frameSvc.js
+++ b/app/frames/frameSvc.js
@@ -1,20 +1,22 @@
-const moment = require("moment");
+import moment from "moment";
+import PubSub from "pubsub-js";
 
-function frameSvc(
-  $rootScope,
-  stateSvc
-) {
+export default function frameSvc(stateSvc) {
   const svc = {};
 
-  $rootScope.$on("updateStoryframes", (event, chapters) => {
+  PubSub.subscribe("updateStoryframes", (event, chapters) => {
     stateSvc.config.storyframes = [[]];
     for (let c = 0; c < chapters.length; c++) {
       for (let f = 0; f < chapters[c].storyframes.length; f++) {
         const coords = JSON.parse(chapters[0].storyframes[f].center);
         stateSvc.config.storyframes.push({
           title: chapters[c].storyframes[f].title,
-          startDate: moment.unix(chapters[c].storyframes[f].start_time).format("YYYY-MM-DD"),
-          endDate: moment.unix(chapters[c].storyframes[f].end_time).format("YYYY-MM-DD"),
+          startDate: moment
+            .unix(chapters[c].storyframes[f].start_time)
+            .format("YYYY-MM-DD"),
+          endDate: moment
+            .unix(chapters[c].storyframes[f].end_time)
+            .format("YYYY-MM-DD"),
           bb1: [coords[0][0], coords[0][1]],
           bb2: [coords[1][0], coords[1][1]],
           bb3: [coords[2][0], coords[2][1]],
@@ -29,6 +31,3 @@ function frameSvc(
 
   return svc;
 }
-
-
-module.exports = frameSvc;

--- a/app/frames/index.js
+++ b/app/frames/index.js
@@ -1,7 +1,7 @@
-const angular = require("angular");
-const frameController = require("./frameController.js");
-const frameSvc = require("./frameSvc.js");
+import frameController from "./frameController.js";
+import frameSvc from "./frameSvc.js";
 
-angular.module("composer")
+angular
+  .module("composer")
   .factory("frameSvc", frameSvc)
   .controller("frameController", frameController);

--- a/app/layers/layerSvc.js
+++ b/app/layers/layerSvc.js
@@ -70,7 +70,6 @@ function layerSvc($http, appConfig, MapManager, stateSvc) {
 
   svc.getApiResultsThenAddLayer = layerName => {
     svc.getSearchBarResultsIndex(layerName).then(data => {
-      console.log("!!!REX", data);
       svc.addLayerFromApiResults({
         searchObjects: data,
         searchValue: layerName

--- a/app/layers/layerSvc.js
+++ b/app/layers/layerSvc.js
@@ -1,4 +1,6 @@
-function layerSvc($rootScope, $http, appConfig, MapManager, stateSvc) {
+import PubSub from "pubsub-js";
+
+function layerSvc($http, appConfig, MapManager, stateSvc) {
   const layerStyleTimeStamps = {};
   const svc = {};
 
@@ -53,7 +55,7 @@ function layerSvc($rootScope, $http, appConfig, MapManager, stateSvc) {
   svc.removeLayer = lyr => {
     stateSvc.removeLayer(lyr.values_.uuid);
     window.storyMap.removeStoryLayer(lyr);
-    $rootScope.$broadcast("layerRemoved");
+    PubSub.publish("layerRemoved");
   };
 
   svc.toggleVisibleLayer = lyr => {

--- a/app/layers/spec/featureManagerSvc.spec.js
+++ b/app/layers/spec/featureManagerSvc.spec.js
@@ -1,16 +1,16 @@
 describe("featureManagerSvc", () => {
-  let featureManagerSvc;
+  let svc;
 
   beforeEach(module("composer"));
   beforeEach(
-    inject(($location, _featureManagerSvc_) => {
-      featureManagerSvc = _featureManagerSvc_;
+    inject(_featureManagerSvc_ => {
+      svc = _featureManagerSvc_;
     })
   );
 
   describe("createVectorLayer", () => {
     it("should return a layer with metadata that has `vectorEditLayer` set to `true`", () => {
-      const testLayer = featureManagerSvc.createVectorLayer();
+      const testLayer = svc.createVectorLayer();
       expect(testLayer.get("metadata").vectorEditLayer).toBe(true);
     });
   });

--- a/app/layers/spec/featureManagerSvc.spec.js
+++ b/app/layers/spec/featureManagerSvc.spec.js
@@ -3,7 +3,7 @@ describe("featureManagerSvc", () => {
 
   beforeEach(module("composer"));
   beforeEach(
-    inject(($rootScope, $location, _featureManagerSvc_) => {
+    inject(($location, _featureManagerSvc_) => {
       featureManagerSvc = _featureManagerSvc_;
     })
   );

--- a/app/layers/spec/getSearchBarResultsIndex.spec.js
+++ b/app/layers/spec/getSearchBarResultsIndex.spec.js
@@ -2,12 +2,10 @@ describe("getSearchBarResultsIndex", () => {
   let appConfig;
   let httpBackend;
   let searchBarRes;
-  let layerSvc;
 
   beforeEach(module("composer"));
   beforeEach(
-    inject(($httpBackend, _appConfig_, _layerSvc_) => {
-      layerSvc = _layerSvc_;
+    inject(($httpBackend, _appConfig_) => {
       appConfig = _appConfig_;
       httpBackend = $httpBackend;
 

--- a/app/layers/spec/layerOptionsSvc.spec.js
+++ b/app/layers/spec/layerOptionsSvc.spec.js
@@ -4,7 +4,7 @@ describe("layerOptionsSvc", () => {
 
   beforeEach(module("composer"));
   beforeEach(
-    inject(($rootScope, _layerOptionsSvc_) => {
+    inject(_layerOptionsSvc_ => {
       layerOptionsSvc = _layerOptionsSvc_;
       testServer = {
         path: "/testpath"

--- a/app/map/mapManager.js
+++ b/app/map/mapManager.js
@@ -1,6 +1,7 @@
+import PubSub from "pubsub-js";
+
 function MapManager(
   $http,
-  $rootScope,
   appConfig,
   stStoryMapBuilder,
   stEditableLayerBuilder,
@@ -76,7 +77,7 @@ function MapManager(
             .fit(extent, svc.storyMap.getMap().getSize());
         }
         // Brodcast so we can request the legend for this layer.
-        $rootScope.$broadcast("layerAdded");
+        PubSub.publish("layerAdded");
       });
 
   svc.addLayer = args => {

--- a/app/map/spec/mapManager.spec.js
+++ b/app/map/spec/mapManager.spec.js
@@ -4,7 +4,7 @@ describe("mapManager", () => {
 
   beforeEach(module("composer"));
   beforeEach(
-    inject(($location, $q, _MapManager_, _stateSvc_) => {
+    inject(($location, _MapManager_, _stateSvc_) => {
       stateSvc = _stateSvc_;
       MapManager = _MapManager_;
     })

--- a/app/map/spec/mapManager.spec.js
+++ b/app/map/spec/mapManager.spec.js
@@ -4,7 +4,7 @@ describe("mapManager", () => {
 
   beforeEach(module("composer"));
   beforeEach(
-    inject(($rootScope, $location, $q, _MapManager_, _stateSvc_) => {
+    inject(($location, $q, _MapManager_, _stateSvc_) => {
       stateSvc = _stateSvc_;
       MapManager = _MapManager_;
     })

--- a/app/pins/spec/pinSvc.spec.js
+++ b/app/pins/spec/pinSvc.spec.js
@@ -123,15 +123,15 @@ describe("pinSvc", () => {
   describe("removeChapter", () => {
     it("remove the specified chapter index", () => {
       expect(pinSvc.pins.length).toBe(1);
-      pinSvc.pins[0].push("ch1");
-      expect(pinSvc.pins[0][0]).toBe("ch1");
+      pinSvc.pins[0].push({ name: "ch1" });
+      expect(pinSvc.pins[0][0].name).toBe("ch1");
       pinSvc.addChapter();
       expect(pinSvc.pins.length).toBe(2);
-      pinSvc.pins[1].push("ch2");
-      expect(pinSvc.pins[1][0]).toBe("ch2");
+      pinSvc.pins[1].push({ name: "ch2" });
+      expect(pinSvc.pins[1][0].name).toBe("ch2");
       pinSvc.removeChapter(0);
       expect(pinSvc.pins.length).toBe(1);
-      expect(pinSvc.pins[0][0]).toBe("ch2");
+      expect(pinSvc.pins[0][0].name).toBe("ch2");
       expect(pinSvc.pins[1]).toBeUndefined();
     });
   });
@@ -241,11 +241,11 @@ describe("pinSvc", () => {
 
   describe("reorderPins", () => {
     it("should reoder a pin collection given the `to` and `from` index", () => {
-      pinSvc.pins = [["1"], ["2"], ["3"]];
+      pinSvc.pins = [[{ name: "1" }], [{ name: "2" }], [{ name: "3" }]];
       pinSvc.reorderPins(0, 1);
-      expect(pinSvc.pins[0][0]).toBe("2");
+      expect(pinSvc.pins[0][0].name).toBe("2");
       pinSvc.reorderPins(2, 0);
-      expect(pinSvc.pins[0][0]).toBe("3");
+      expect(pinSvc.pins[0][0].name).toBe("3");
     });
   });
 

--- a/app/pins/spec/pinSvc.spec.js
+++ b/app/pins/spec/pinSvc.spec.js
@@ -8,15 +8,20 @@ Test Pin 5,Example Content about pin,http://#,7/1/91,3/20/92,35.78,28.98,TRUE,TR
 Test Pin 6,Example Content about pin,http://#,7/1/91,3/20/92,35.78,28.98,TRUE,TRUE,FALSE,FALSE`;
 
 describe("pinSvc", () => {
-  let rootScope, httpBackend, pinSvc, stateSvc, pin, serverFeatures, validProperties, pinConfigs;
+  let httpBackend,
+    pinSvc,
+    stateSvc,
+    pin,
+    serverFeatures,
+    validProperties,
+    pinConfigs;
 
   beforeEach(module("composer"));
   beforeEach(
-    inject(($rootScope, $httpBackend, _pinSvc_, _stateSvc_) => {
+    inject(($httpBackend, _pinSvc_, _stateSvc_) => {
       pinSvc = _pinSvc_;
       stateSvc = _stateSvc_;
       httpBackend = $httpBackend;
-      rootScope = $rootScope;
 
       pin = new pinSvc.Pin({
         geometry: {
@@ -337,14 +342,10 @@ describe("pinSvc", () => {
       pinSvc.createPinsWithCSV(results);
       expect(pins.length).toBe(12);
     });
-    xit("exports to JSON", () => {
-
-    });
+    xit("exports to JSON", () => {});
   });
 
   describe("StoryPin Overlay", () => {
-    xit("has an overlay for each StoryPin in the DOM", () => {
-
-    });
+    xit("has an overlay for each StoryPin in the DOM", () => {});
   });
 });

--- a/app/state/spec/stateSvc.spec.js
+++ b/app/state/spec/stateSvc.spec.js
@@ -4,7 +4,7 @@ describe("stateSvc", () => {
 
   beforeEach(module("composer"));
   beforeEach(
-    inject(($rootScope, $location, _stateSvc_) => {
+    inject(($location, _stateSvc_) => {
       stateSvc = _stateSvc_;
       location = $location;
     })

--- a/app/state/stateSvc.js
+++ b/app/state/stateSvc.js
@@ -1,7 +1,8 @@
+import PubSub from "pubsub-js";
+
 function stateSvc(
   $http,
   $location,
-  $rootScope,
   $q,
   stAnnotationsStore,
   stLocalStorageSvc,
@@ -52,7 +53,7 @@ function stateSvc(
     svc.config = configSvc.getMapstoryConfig();
     window.config = svc.config;
     svc.originalConfig = window.config;
-    $rootScope.$broadcast("configInitialized");
+    PubSub.publish("configInitialized");
   }
 
   svc.initConfig = () => {
@@ -72,7 +73,7 @@ function stateSvc(
           svc.config = configSvc.getMapstoryConfig(data);
           window.config = svc.config;
           svc.originalConfig = data;
-          $rootScope.$broadcast("configInitialized");
+          PubSub.publish("configInitialized");
         })
         .fail(() => {
           initializeNewConfig();
@@ -121,14 +122,14 @@ function stateSvc(
       url: `/api/mapstories/${storyId}`,
       method: "GET"
     }).then(data => {
-      $rootScope.$broadcast("updateStorypins", data.data.chapters);
-      $rootScope.$broadcast("updateStoryframes", data.data.chapters);
+      PubSub.publish("updateStorypins", data.data.chapters);
+      PubSub.publish("updateStoryframes", data.data.chapters);
     });
 
   /**
    * Event responder for Init has finished.
    */
-  $rootScope.$on("configInitialized", () => {
+  PubSub.subscribe("configInitialized", () => {
     // This means we are in a new temp mapstory. No id has been created for this yet.
     if (svc.isTempStory()) {
       // Initialize empty arrays for storypins
@@ -197,7 +198,7 @@ function stateSvc(
     let chapter = 1;
     const path = $location.path();
     if (path && path.indexOf("/chapter") === 0) {
-      const matches = /\d+/.exec(path)
+      const matches = /\d+/.exec(path);
       if (matches !== null) {
         chapter = matches[0];
       }
@@ -407,7 +408,7 @@ function stateSvc(
       // No need to broadcast
       return;
     }
-    $rootScope.$broadcast("loadids", idArray, chapterId);
+    PubSub.publish("loadids", idArray, chapterId);
   };
 
   svc.saveStoryFramesToServer = mapId => {

--- a/app/ui/legend.directive.js
+++ b/app/ui/legend.directive.js
@@ -1,6 +1,6 @@
 import PubSub from "pubsub-js";
 
-export default function legendDirective(layerSvc) {
+function legendDirective(layerSvc) {
   let legendOpen = false;
 
   return {
@@ -53,3 +53,5 @@ export default function legendDirective(layerSvc) {
     }
   };
 }
+
+export default legendDirective;

--- a/app/ui/legend.directive.js
+++ b/app/ui/legend.directive.js
@@ -1,4 +1,6 @@
-function legendDirective(layerSvc) {
+import PubSub from "pubsub-js";
+
+export default function legendDirective(layerSvc) {
   let legendOpen = false;
 
   return {
@@ -33,13 +35,13 @@ function legendDirective(layerSvc) {
 
       scope.getLegendUrl = layerSvc.getLegendUrl;
 
-      scope.$on("layerAdded", () => {
+      PubSub.subscribe("layerAdded", () => {
         if (legendOpen === false) {
           openLegend();
         }
       });
 
-      scope.$on("layerRemoved", () => {
+      PubSub.subscribe("layerRemoved", () => {
         // close the legend if the last layer is removed
         if (
           legendOpen === true &&
@@ -51,5 +53,3 @@ function legendDirective(layerSvc) {
     }
   };
 }
-
-export default legendDirective;

--- a/app/ui/navigationSvc.js
+++ b/app/ui/navigationSvc.js
@@ -1,4 +1,6 @@
-function navigationSvc($location, $rootScope, $log, stateSvc, appConfig) {
+import PubSub from "pubsub-js";
+
+function navigationSvc($location, $log, stateSvc, appConfig) {
   const svc = {};
 
   /**
@@ -11,17 +13,13 @@ function navigationSvc($location, $rootScope, $log, stateSvc, appConfig) {
     if (nextChapter <= stateSvc.getChapterCount()) {
       // Go to next
       $log.info("Going to Chapter ", nextChapter);
-      $rootScope.$broadcast(
-        "changingChapter",
-        thisChapter - 1,
-        nextChapter - 1
-      ); // (-1 because indeces start at 1)
+      PubSub.publish("changingChapter", thisChapter - 1, nextChapter - 1); // (-1 because indeces start at 1)
       $location.path(appConfig.routes.chapter + nextChapter);
     } else {
       // Go from last to first.
       $log.info("Going to Chapter ", 1);
       $location.path("");
-      $rootScope.$broadcast("changingChapter", thisChapter - 1, 0);
+      PubSub.publish("changingChapter", thisChapter - 1, 0);
     }
   };
 
@@ -35,17 +33,13 @@ function navigationSvc($location, $rootScope, $log, stateSvc, appConfig) {
     if (previousChapter > 0) {
       // Go to previous
       $log.info("Going to the Chapter ", previousChapter);
-      $rootScope.$broadcast(
-        "changingChapter",
-        thisChapter - 1,
-        previousChapter - 1
-      ); // (-1 because indeces start at 1)
+      PubSub.publish("changingChapter", thisChapter - 1, previousChapter - 1); // (-1 because indeces start at 1)
       $location.path(appConfig.routes.chapter + previousChapter);
     } else {
       // Go from first to last.
       $log.info("Going to Chapter ", stateSvc.getChapterCount());
       svc.goToChapter(stateSvc.getChapterCount());
-      $rootScope.$broadcast(
+      PubSub.publish(
         "changingChapter",
         thisChapter - 1,
         stateSvc.getChapterCount() - 1

--- a/app/ui/spec/navigationSvc.spec.js
+++ b/app/ui/spec/navigationSvc.spec.js
@@ -1,49 +1,51 @@
 describe("navigationSvc", () => {
-
   let config;
   let navigationSvc;
   let location;
   let stateSvc;
 
   beforeEach(module("composer"));
-  beforeEach(inject(($rootScope, $location, _navigationSvc_, _stateSvc_, _appConfig_) => {
-    config = _appConfig_;
-    navigationSvc = _navigationSvc_;
-    stateSvc = _stateSvc_;
-    location = $location;
-  }));
+  beforeEach(
+    inject(($location, _navigationSvc_, _stateSvc_, _appConfig_) => {
+      config = _appConfig_;
+      navigationSvc = _navigationSvc_;
+      stateSvc = _stateSvc_;
+      location = $location;
+    })
+  );
 
   describe("nextChapter", () => {
-    beforeEach(inject(($controller, $rootScope, $compile) => {
-      spyOn(location, "path");
-    }));
+    beforeEach(
+      inject(($controller, $compile) => {
+        spyOn(location, "path");
+      })
+    );
 
     it("should update the location path to the next chapter if it exists", () => {
-      stateSvc.setConfig({chapters:[{},{}]});
+      stateSvc.setConfig({ chapters: [{}, {}] });
       navigationSvc.nextChapter();
       expect(location.path).toHaveBeenCalledWith(config.routes.chapter + 2);
     });
 
     it("should update the location path to the first chapter if there is no next chapter ", () => {
-      stateSvc.setConfig({chapters:[{}]});
+      stateSvc.setConfig({ chapters: [{}] });
       navigationSvc.nextChapter();
       expect(location.path).toHaveBeenCalledWith("");
     });
   });
 
   describe("previous chapter", () => {
-    beforeEach(inject(($rootScope, $compile) => {
-    }));
+    beforeEach(inject($compile => {}));
 
     it("should update the location path to the previous chapter if it exists", () => {
-      stateSvc.setConfig({chapters:[{},{},{}]});
+      stateSvc.setConfig({ chapters: [{}, {}, {}] });
       spyOn(location, "path").and.returnValue("/chapter/3");
       navigationSvc.previousChapter();
       expect(location.path).toHaveBeenCalledWith(config.routes.chapter + 2);
     });
 
     it("should update the location path to the first chapter if there is no previous chapter ", () => {
-      stateSvc.setConfig({chapters:[{}]});
+      stateSvc.setConfig({ chapters: [{}] });
       spyOn(location, "path");
       navigationSvc.previousChapter();
       expect(location.path).toHaveBeenCalledWith("/chapter/1");

--- a/karma.config.js
+++ b/karma.config.js
@@ -2,7 +2,7 @@ const webpackConfig = require("./webpack.config.js");
 
 const browserMode = false;
 
-module.exports = (config) => {
+module.exports = config => {
   config.set({
     basePath: ".",
     client: {
@@ -12,7 +12,7 @@ module.exports = (config) => {
     reporters: ["mocha"],
     port: 9876,
     colors: true,
-    logLevel: config.LOG_INFO,
+    logLevel: browserMode ? config.LOG_DEBUG : config.LOG_INFO,
     autoWatch: false,
     browsers: browserMode ? ["Chrome"] : ["PhantomJS"],
     singleRun: !browserMode,

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "jquery": "3.3.1",
     "moment": "^2.20.1",
     "papaparse": "^4.3.7",
+    "pubsub-js": "^1.6.0",
     "story-tools": "./deps/story-tools"
   },
   "repository": "https://github.com/MapStory/story-tools-composer",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -52,7 +52,12 @@ module.exports = {
   entry: {
     app: ["babel-polyfill", "./app/app.js"],
     style: "./style/style.js",
-    vendor: ["angular", "angular-bootstrap-colorpicker", "angular-translate", "angular-animate", "papaparse"]
+    vendor: [
+      "angular",
+      "angular-bootstrap-colorpicker",
+      "angular-translate",
+      "angular-animate"
+    ]
   },
   output: {
     path: `${__dirname}/build`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7743,6 +7743,10 @@ public-encrypt@^4.0.0:
     parse-asn1 "^5.0.0"
     randombytes "^2.0.1"
 
+pubsub-js@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/pubsub-js/-/pubsub-js-1.6.0.tgz#232d36485ce7905a54629ec5783d9f6f4c638026"
+
 punycode@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"


### PR DESCRIPTION
- Replace all instances of `$RootScope` with PubSub.js.
- Replace Node module syntax with ES6 syntax.
- Fix StoryPin tests that were passing strings where objects were expected (caused downstream type errors).
- Cleanup tests.
- Cleanup various formatting issues. 

Run `yarn install` to test. 