### PR TITLE
Add handling for proxying service urls to support pki protected services

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -49,7 +49,8 @@ module.constant("appConfig", {
       canStyleWMS: true
     }
   ],
-  iconCommonsHost: "http://mapstory.dev.boundlessgeo.com"
+  iconCommonsHost: "http://mapstory.dev.boundlessgeo.com",
+  proxy: window.mapstory.composer.config.proxy
 });
 
 module.run(() => {

--- a/app/layers/layerOptionsSvc.js
+++ b/app/layers/layerOptionsSvc.js
@@ -1,3 +1,5 @@
+import utils from "app/utils/utils";
+
 function layerOptionsSvc() {
   const svc = {};
 
@@ -20,10 +22,12 @@ function layerOptionsSvc() {
       name = parts[1];
     }
 
+    // TODO: Will the server arg passed in have the use_proxy param?
     const url =
+      utils.useProxyUrlParam(utils.getUseProxyParam(server),
       server && server.type === "remote"
         ? server.absolutePath
-        : `${server.path + workspace}/${name}/wms`;
+        : `${server.path + workspace}/${name}/wms`, appConfig.proxy);
     const id = `${workspace}:${name}`;
     const options = {
       id,

--- a/app/utils/utils.js
+++ b/app/utils/utils.js
@@ -26,5 +26,20 @@ export default {
       1}/${today.getDate()}/${today.getFullYear()}`;
     const datetime = `${date} ${formatAMPM(today)}`;
     return datetime;
+  },
+  getUseProxyParam: server => {
+    return goog.isDefAndNotNull(server.use_proxy) ? server.use_proxy : false;
+  },
+  useProxyUrlParam: (use_proxy, url, proxy = "/proxy/?url=") => {
+    if (goog.isDefAndNotNull(use_proxy) && goog.isDefAndNotNull(proxy)
+        && use_proxy === true) {
+      url = decodeURIComponent(url);
+      if (url.indexOf(proxy) < 0) {
+        url = proxy + encodeURIComponent(url);
+      } else {
+        url = encodeURIComponent(url);
+      }
+    }
+    return url;
   }
 };

--- a/partials/standaloneConfig.js
+++ b/partials/standaloneConfig.js
@@ -7,6 +7,8 @@ window.mapstory.composer.config = {
   userprofilename:  "Tester" ,
   userprofileemail:  "test@test.org" ,
   currentLanguage: "en",
+  // TODO: How to assign this to django PROXY_URL?
+  // proxy: "{{ PROXY_URL }}" !== '' ? "{{ PROXY_URL }}" : "/proxy/?url=",
   proxy: "/proxy/?url=",
   rest: "/maps/",
   ajaxLoginUrl: "/account/ajax_login",


### PR DESCRIPTION
Two remaining questions:

1) Will servers in the `layerOptions` service have our `use_proxy` parameter? The `use_proxy` parameter is attached to the `MapLayer` or `GXPLayer` object. What is `server`?
2) How can Django context variables be accessed in the app? `{{ THEME }}` is present in the index.html, but making changes to the HTML templates did not seem to be working. The goal is to add it to the config parameters where it is currently commented out.